### PR TITLE
支持两套Agent身份配置

### DIFF
--- a/docs/agent-mcp-current-contract.md
+++ b/docs/agent-mcp-current-contract.md
@@ -17,6 +17,7 @@ This document is the backend-owned current contract for Dirextalk Agent state, N
 - Bridge availability is Matrix room state type `io.dirextalk.agent.status`, state key `@agent:<server>`, with content field `online`.
 - The running bridge publishes `online=true` or `online=false` through its Matrix session. Server startup or repair and `agent.config.update enabled=false` may publish `online=false` as a safe fallback.
 - The server does not infer bridge availability from Agent configuration, `/sync`, realtime WebSocket lifetime, or Matrix presence. `sync.bootstrap` returns `agent_room_id`, not `agent_online`, and does not emit `agent.presence`.
+- `agent.config.get` returns two mode-specific Agent identities: `native_agent_identity` for Ying / Native Agent and `online_agent_identity` for Your Agent / Matrix bridge Agent. Each identity contains `display_name` and `avatar_url`. Top-level `display_name` and `avatar_url` remain legacy compatibility fields and mirror the effective Native Agent identity. A legacy `agent.config.update` that only sends top-level identity fields updates both mode identities; when nested identity fields are sent, they are merged per mode and take precedence for that mode. `agent.matrix_session.create` uses `online_agent_identity` for the Matrix Agent session profile.
 
 ## Native Agent Ownership
 

--- a/docs/api-interface-change-record.md
+++ b/docs/api-interface-change-record.md
@@ -1,6 +1,12 @@
 # API Interface Change Record
 
-Last updated: 2026-07-23
+Last updated: 2026-07-30
+
+## 2026-07-30 Agent Mode-Specific Identities
+
+`agent.config.get` and `agent.config.update` now support mode-specific Agent identity objects. `native_agent_identity` owns Ying / Native Agent `display_name` and `avatar_url`; `online_agent_identity` owns Your Agent / Matrix bridge `display_name` and `avatar_url`. The existing top-level `display_name` and `avatar_url` remain for legacy clients and mirror the effective Native Agent identity in responses.
+
+A legacy update that sends only top-level identity fields synchronizes both mode identities. When nested identities are sent, updates merge per mode so one mode can change without clearing or overwriting the other; nested values take precedence for their mode. `agent.matrix_session.create` uses `online_agent_identity` when creating or ensuring the Matrix Agent session.
 
 ## 2026-07-23 Native Agent Anthropic, Gemini, And xAI Model Lists
 

--- a/internal/dirextalkdomain/types.go
+++ b/internal/dirextalkdomain/types.go
@@ -58,14 +58,21 @@ type ContactRecord struct {
 }
 
 type AgentConfig struct {
-	DisplayName       string         `json:"display_name"`
-	AvatarURL         string         `json:"avatar_url"`
-	ContextWindow     int64          `json:"context_window"`
-	Enabled           bool           `json:"enabled"`
-	Model             string         `json:"model"`
-	SystemPrompt      string         `json:"system_prompt"`
-	MCPBlockedRoomIDs []string       `json:"mcp_blocked_room_ids"`
-	Native            map[string]any `json:"-"`
+	DisplayName         string              `json:"display_name"`
+	AvatarURL           string              `json:"avatar_url"`
+	NativeAgentIdentity AgentIdentityConfig `json:"native_agent_identity"`
+	OnlineAgentIdentity AgentIdentityConfig `json:"online_agent_identity"`
+	ContextWindow       int64               `json:"context_window"`
+	Enabled             bool                `json:"enabled"`
+	Model               string              `json:"model"`
+	SystemPrompt        string              `json:"system_prompt"`
+	MCPBlockedRoomIDs   []string            `json:"mcp_blocked_room_ids"`
+	Native              map[string]any      `json:"-"`
+}
+
+type AgentIdentityConfig struct {
+	DisplayName string `json:"display_name"`
+	AvatarURL   string `json:"avatar_url"`
 }
 
 type Channel struct {
@@ -298,13 +305,15 @@ type EventBounds struct {
 
 func (c *AgentConfig) UnmarshalJSON(data []byte) error {
 	type agentConfigJSON struct {
-		DisplayName       string   `json:"display_name"`
-		AvatarURL         string   `json:"avatar_url"`
-		ContextWindow     int64    `json:"context_window"`
-		Enabled           bool     `json:"enabled"`
-		Model             string   `json:"model"`
-		SystemPrompt      string   `json:"system_prompt"`
-		MCPBlockedRoomIDs []string `json:"mcp_blocked_room_ids"`
+		DisplayName         string              `json:"display_name"`
+		AvatarURL           string              `json:"avatar_url"`
+		NativeAgentIdentity AgentIdentityConfig `json:"native_agent_identity"`
+		OnlineAgentIdentity AgentIdentityConfig `json:"online_agent_identity"`
+		ContextWindow       int64               `json:"context_window"`
+		Enabled             bool                `json:"enabled"`
+		Model               string              `json:"model"`
+		SystemPrompt        string              `json:"system_prompt"`
+		MCPBlockedRoomIDs   []string            `json:"mcp_blocked_room_ids"`
 	}
 	var known agentConfigJSON
 	if err := json.Unmarshal(data, &known); err != nil {
@@ -319,6 +328,18 @@ func (c *AgentConfig) UnmarshalJSON(data []byte) error {
 	}
 	c.DisplayName = known.DisplayName
 	c.AvatarURL = known.AvatarURL
+	c.NativeAgentIdentity = known.NativeAgentIdentity
+	c.OnlineAgentIdentity = known.OnlineAgentIdentity
+	legacyIdentity := AgentIdentityConfig{
+		DisplayName: known.DisplayName,
+		AvatarURL:   known.AvatarURL,
+	}
+	if agentIdentityConfigEmpty(c.NativeAgentIdentity) {
+		c.NativeAgentIdentity = legacyIdentity
+	}
+	if agentIdentityConfigEmpty(c.OnlineAgentIdentity) {
+		c.OnlineAgentIdentity = legacyIdentity
+	}
 	c.ContextWindow = known.ContextWindow
 	c.Enabled = known.Enabled
 	c.Model = known.Model
@@ -333,7 +354,7 @@ func (c *AgentConfig) UnmarshalJSON(data []byte) error {
 }
 
 func (c AgentConfig) MarshalJSON() ([]byte, error) {
-	out := make(map[string]any, len(c.Native)+7)
+	out := make(map[string]any, len(c.Native)+9)
 	for key, value := range c.Native {
 		if !agentConfigKnownJSONKey(key) {
 			out[key] = value
@@ -341,6 +362,8 @@ func (c AgentConfig) MarshalJSON() ([]byte, error) {
 	}
 	out["display_name"] = c.DisplayName
 	out["avatar_url"] = c.AvatarURL
+	out["native_agent_identity"] = c.NativeAgentIdentity
+	out["online_agent_identity"] = c.OnlineAgentIdentity
 	out["context_window"] = c.ContextWindow
 	out["enabled"] = c.Enabled
 	out["model"] = c.Model
@@ -353,6 +376,8 @@ func agentConfigKnownJSONKeys() []string {
 	return []string{
 		"display_name",
 		"avatar_url",
+		"native_agent_identity",
+		"online_agent_identity",
 		"context_window",
 		"enabled",
 		"model",
@@ -368,6 +393,11 @@ func agentConfigKnownJSONKey(key string) bool {
 		}
 	}
 	return false
+}
+
+func agentIdentityConfigEmpty(identity AgentIdentityConfig) bool {
+	return strings.TrimSpace(identity.DisplayName) == "" &&
+		strings.TrimSpace(identity.AvatarURL) == ""
 }
 
 func (m MemberRecord) MarshalJSON() ([]byte, error) {

--- a/internal/dirextalkdomain/types_test.go
+++ b/internal/dirextalkdomain/types_test.go
@@ -52,16 +52,25 @@ func TestMemberRecordJSONIncludesCompatibilityFields(t *testing.T) {
 
 func TestAgentConfigJSONPreservesNativeFields(t *testing.T) {
 	raw, err := json.Marshal(AgentConfig{
-		DisplayName:       "Agent",
-		AvatarURL:         "mxc://agent",
+		DisplayName: "Agent",
+		AvatarURL:   "mxc://agent",
+		NativeAgentIdentity: AgentIdentityConfig{
+			DisplayName: "Ying",
+			AvatarURL:   "mxc://ying",
+		},
+		OnlineAgentIdentity: AgentIdentityConfig{
+			DisplayName: "Your Agent",
+			AvatarURL:   "mxc://online",
+		},
 		ContextWindow:     64,
 		Enabled:           true,
 		Model:             "model-a",
 		SystemPrompt:      "system",
 		MCPBlockedRoomIDs: []string{"!blocked:example.com"},
 		Native: map[string]any{
-			"skills":       []any{map[string]any{"id": "skill-a"}},
-			"display_name": "native-shadow",
+			"skills":                []any{map[string]any{"id": "skill-a"}},
+			"display_name":          "native-shadow",
+			"native_agent_identity": map[string]any{"display_name": "shadow"},
 		},
 	})
 	if err != nil {
@@ -78,12 +87,20 @@ func TestAgentConfigJSONPreservesNativeFields(t *testing.T) {
 	if _, ok := encoded["skills"]; !ok {
 		t.Fatalf("native skills field should be preserved, got %#v", encoded)
 	}
+	nativeIdentity := encoded["native_agent_identity"].(map[string]any)
+	onlineIdentity := encoded["online_agent_identity"].(map[string]any)
+	if nativeIdentity["display_name"] != "Ying" || nativeIdentity["avatar_url"] != "mxc://ying" ||
+		onlineIdentity["display_name"] != "Your Agent" || onlineIdentity["avatar_url"] != "mxc://online" {
+		t.Fatalf("agent identities should round-trip as known fields, got %#v", encoded)
+	}
 
 	var decoded AgentConfig
 	if err := json.Unmarshal(raw, &decoded); err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
-	if decoded.DisplayName != "Agent" || decoded.Model != "model-a" || !decoded.Enabled {
+	if decoded.DisplayName != "Agent" || decoded.Model != "model-a" || !decoded.Enabled ||
+		decoded.NativeAgentIdentity.DisplayName != "Ying" ||
+		decoded.OnlineAgentIdentity.DisplayName != "Your Agent" {
 		t.Fatalf("expected known fields to round-trip, got %#v", decoded)
 	}
 	if _, ok := decoded.Native["skills"]; !ok {
@@ -91,6 +108,26 @@ func TestAgentConfigJSONPreservesNativeFields(t *testing.T) {
 	}
 	if _, ok := decoded.Native["display_name"]; ok {
 		t.Fatalf("known fields must not remain in Native, got %#v", decoded.Native)
+	}
+	if _, ok := decoded.Native["native_agent_identity"]; ok {
+		t.Fatalf("identity fields must not remain in Native, got %#v", decoded.Native)
+	}
+}
+
+func TestAgentConfigJSONBackfillsModeIdentitiesFromLegacyFields(t *testing.T) {
+	var decoded AgentConfig
+	if err := json.Unmarshal([]byte(`{
+		"display_name":"Legacy Agent",
+		"avatar_url":"mxc://legacy",
+		"context_window":48
+	}`), &decoded); err != nil {
+		t.Fatalf("Unmarshal legacy config failed: %v", err)
+	}
+	if decoded.NativeAgentIdentity.DisplayName != "Legacy Agent" ||
+		decoded.NativeAgentIdentity.AvatarURL != "mxc://legacy" ||
+		decoded.OnlineAgentIdentity.DisplayName != "Legacy Agent" ||
+		decoded.OnlineAgentIdentity.AvatarURL != "mxc://legacy" {
+		t.Fatalf("expected legacy identity fallback, got %#v", decoded)
 	}
 }
 

--- a/p2p/internal/agent/account.go
+++ b/p2p/internal/agent/account.go
@@ -83,32 +83,13 @@ func (m *Module) updateConfig(ctx context.Context, params map[string]any) (any, 
 		return nil, err
 	}
 
-	values := actionbase.Params(params)
 	disableAgent := false
 	config, actionErr := account.UpdateConfig(ctx, func(current dirextalkdomain.AgentConfig) dirextalkdomain.AgentConfig {
-		if displayName := values.String("display_name"); displayName != "" {
-			current.DisplayName = displayName
-		}
-		if _, ok := params["avatar_url"]; ok {
-			current.AvatarURL = values.String("avatar_url")
-		}
-		if contextWindow := values.Int64("context_window"); contextWindow > 0 {
-			current.ContextWindow = contextWindow
-		}
+		next := ApplyConfigUpdate(current, params)
 		if _, ok := params["enabled"]; ok {
-			current.Enabled = values.Bool("enabled")
-			disableAgent = !current.Enabled
+			disableAgent = !next.Enabled
 		}
-		if model := values.String("model"); model != "" {
-			current.Model = model
-		}
-		if systemPrompt := values.String("system_prompt"); systemPrompt != "" {
-			current.SystemPrompt = systemPrompt
-		}
-		if _, ok := params["mcp_blocked_room_ids"]; ok {
-			current.MCPBlockedRoomIDs = values.Strings("mcp_blocked_room_ids")
-		}
-		return NormalizeConfig(current)
+		return next
 	})
 	if actionErr != nil {
 		return nil, actionErr
@@ -129,9 +110,18 @@ func (m *Module) accountPort() (AccountPort, *actionbase.Error) {
 }
 
 func configResponse(config dirextalkdomain.AgentConfig) map[string]any {
+	config = NormalizeConfig(config)
 	return map[string]any{
-		"display_name":         config.DisplayName,
-		"avatar_url":           config.AvatarURL,
+		"display_name": config.DisplayName,
+		"avatar_url":   config.AvatarURL,
+		"native_agent_identity": map[string]any{
+			"display_name": config.NativeAgentIdentity.DisplayName,
+			"avatar_url":   config.NativeAgentIdentity.AvatarURL,
+		},
+		"online_agent_identity": map[string]any{
+			"display_name": config.OnlineAgentIdentity.DisplayName,
+			"avatar_url":   config.OnlineAgentIdentity.AvatarURL,
+		},
 		"context_window":       config.ContextWindow,
 		"enabled":              config.Enabled,
 		"model":                config.Model,

--- a/p2p/internal/agent/config.go
+++ b/p2p/internal/agent/config.go
@@ -13,6 +13,13 @@ import (
 
 const LegacyPluginID = "io.dirextalk.agent"
 
+const (
+	configKeyDisplayName         = "display_name"
+	configKeyAvatarURL           = "avatar_url"
+	configKeyNativeAgentIdentity = "native_agent_identity"
+	configKeyOnlineAgentIdentity = "online_agent_identity"
+)
+
 // LegacyPluginStore is the only plugin persistence capability needed to import
 // pre-native Agent configuration during service startup.
 type LegacyPluginStore interface {
@@ -22,9 +29,14 @@ type LegacyPluginStore interface {
 // ToNativeMap combines shared Agent fields and runtime-owned fields while
 // excluding credentials that must never enter portal state.
 func ToNativeMap(cfg dirextalkdomain.AgentConfig) map[string]any {
+	cfg = NormalizeConfig(cfg)
+	nativeIdentity := NativeAgentIdentity(cfg)
+	onlineIdentity := OnlineAgentIdentity(cfg)
 	out := cloneMap(cfg.Native)
-	out["display_name"] = cfg.DisplayName
-	out["avatar_url"] = cfg.AvatarURL
+	out[configKeyDisplayName] = nativeIdentity.DisplayName
+	out[configKeyAvatarURL] = nativeIdentity.AvatarURL
+	out[configKeyNativeAgentIdentity] = identityMap(nativeIdentity)
+	out[configKeyOnlineAgentIdentity] = identityMap(onlineIdentity)
 	out["context_window"] = cfg.ContextWindow
 	out["enabled"] = cfg.Enabled
 	out["model"] = cfg.Model
@@ -43,11 +55,17 @@ func FromNativeMap(current dirextalkdomain.AgentConfig, config map[string]any) d
 	merged = SanitizeNativeConfigMap(merged)
 
 	next := current
-	if _, ok := merged["display_name"]; ok {
-		next.DisplayName = actionbase.String(merged["display_name"])
+	if _, ok := merged[configKeyDisplayName]; ok {
+		next.NativeAgentIdentity.DisplayName = actionbase.String(merged[configKeyDisplayName])
 	}
-	if _, ok := merged["avatar_url"]; ok {
-		next.AvatarURL = actionbase.String(merged["avatar_url"])
+	if _, ok := merged[configKeyAvatarURL]; ok {
+		next.NativeAgentIdentity.AvatarURL = actionbase.String(merged[configKeyAvatarURL])
+	}
+	if _, ok := config[configKeyNativeAgentIdentity]; ok {
+		next.NativeAgentIdentity = mergeIdentity(next.NativeAgentIdentity, config[configKeyNativeAgentIdentity])
+	}
+	if _, ok := config[configKeyOnlineAgentIdentity]; ok {
+		next.OnlineAgentIdentity = mergeIdentity(next.OnlineAgentIdentity, config[configKeyOnlineAgentIdentity])
 	}
 	if value := actionbase.Int64(merged["context_window"]); value > 0 {
 		next.ContextWindow = value
@@ -76,6 +94,57 @@ func FromNativeMap(current dirextalkdomain.AgentConfig, config map[string]any) d
 		next.Native = native
 	} else {
 		next.Native = nil
+	}
+	return NormalizeConfig(next)
+}
+
+// ApplyConfigUpdate merges ProductCore agent.config.update params into the
+// durable Agent configuration while preserving legacy top-level compatibility.
+func ApplyConfigUpdate(current dirextalkdomain.AgentConfig, params map[string]any) dirextalkdomain.AgentConfig {
+	next := current
+	values := actionbase.Params(params)
+	hasNativeIdentity := hasKey(params, configKeyNativeAgentIdentity)
+	hasOnlineIdentity := hasKey(params, configKeyOnlineAgentIdentity)
+
+	if displayName := values.String(configKeyDisplayName); displayName != "" {
+		next.DisplayName = displayName
+		if !hasNativeIdentity {
+			next.NativeAgentIdentity.DisplayName = displayName
+		}
+		if !hasOnlineIdentity {
+			next.OnlineAgentIdentity.DisplayName = displayName
+		}
+	}
+	if _, ok := params[configKeyAvatarURL]; ok {
+		avatarURL := values.String(configKeyAvatarURL)
+		next.AvatarURL = avatarURL
+		if !hasNativeIdentity {
+			next.NativeAgentIdentity.AvatarURL = avatarURL
+		}
+		if !hasOnlineIdentity {
+			next.OnlineAgentIdentity.AvatarURL = avatarURL
+		}
+	}
+	if hasNativeIdentity {
+		next.NativeAgentIdentity = mergeIdentity(next.NativeAgentIdentity, params[configKeyNativeAgentIdentity])
+	}
+	if hasOnlineIdentity {
+		next.OnlineAgentIdentity = mergeIdentity(next.OnlineAgentIdentity, params[configKeyOnlineAgentIdentity])
+	}
+	if contextWindow := values.Int64("context_window"); contextWindow > 0 {
+		next.ContextWindow = contextWindow
+	}
+	if _, ok := params["enabled"]; ok {
+		next.Enabled = values.Bool("enabled")
+	}
+	if model := values.String("model"); model != "" {
+		next.Model = model
+	}
+	if systemPrompt := values.String("system_prompt"); systemPrompt != "" {
+		next.SystemPrompt = systemPrompt
+	}
+	if _, ok := params["mcp_blocked_room_ids"]; ok {
+		next.MCPBlockedRoomIDs = values.Strings("mcp_blocked_room_ids")
 	}
 	return NormalizeConfig(next)
 }
@@ -150,6 +219,8 @@ func MergeLegacyConfig(current dirextalkdomain.AgentConfig, legacy map[string]an
 func NormalizeConfig(cfg dirextalkdomain.AgentConfig) dirextalkdomain.AgentConfig {
 	empty := strings.TrimSpace(cfg.DisplayName) == "" &&
 		strings.TrimSpace(cfg.AvatarURL) == "" &&
+		identityEmpty(cfg.NativeAgentIdentity) &&
+		identityEmpty(cfg.OnlineAgentIdentity) &&
 		cfg.ContextWindow == 0 &&
 		!cfg.Enabled &&
 		strings.TrimSpace(cfg.Model) == "" &&
@@ -157,6 +228,8 @@ func NormalizeConfig(cfg dirextalkdomain.AgentConfig) dirextalkdomain.AgentConfi
 		len(cfg.MCPBlockedRoomIDs) == 0
 	if empty {
 		cfg.DisplayName = "Agent"
+		cfg.NativeAgentIdentity = dirextalkdomain.AgentIdentityConfig{DisplayName: "Agent"}
+		cfg.OnlineAgentIdentity = dirextalkdomain.AgentIdentityConfig{DisplayName: "Agent"}
 		cfg.ContextWindow = 30
 		cfg.Enabled = true
 		return cfg
@@ -167,6 +240,14 @@ func NormalizeConfig(cfg dirextalkdomain.AgentConfig) dirextalkdomain.AgentConfi
 		cfg.DisplayName = strings.TrimSpace(cfg.DisplayName)
 	}
 	cfg.AvatarURL = strings.TrimSpace(cfg.AvatarURL)
+	legacyIdentity := dirextalkdomain.AgentIdentityConfig{
+		DisplayName: cfg.DisplayName,
+		AvatarURL:   cfg.AvatarURL,
+	}
+	cfg.NativeAgentIdentity = normalizeIdentity(cfg.NativeAgentIdentity, legacyIdentity)
+	cfg.OnlineAgentIdentity = normalizeIdentity(cfg.OnlineAgentIdentity, legacyIdentity)
+	cfg.DisplayName = cfg.NativeAgentIdentity.DisplayName
+	cfg.AvatarURL = cfg.NativeAgentIdentity.AvatarURL
 	if cfg.ContextWindow <= 0 {
 		cfg.ContextWindow = 30
 	}
@@ -207,6 +288,8 @@ func sanitizeModelProfiles(profiles []any) []any {
 func configEmpty(cfg dirextalkdomain.AgentConfig) bool {
 	return actionbase.String(cfg.DisplayName) == "" &&
 		actionbase.String(cfg.AvatarURL) == "" &&
+		identityEmpty(cfg.NativeAgentIdentity) &&
+		identityEmpty(cfg.OnlineAgentIdentity) &&
 		cfg.ContextWindow == 0 &&
 		!cfg.Enabled &&
 		actionbase.String(cfg.Model) == "" &&
@@ -217,11 +300,74 @@ func configEmpty(cfg dirextalkdomain.AgentConfig) bool {
 
 func sharedConfigKey(key string) bool {
 	switch key {
-	case "display_name", "avatar_url", "context_window", "enabled", "model", "system_prompt", "mcp_blocked_room_ids":
+	case configKeyDisplayName, configKeyAvatarURL, configKeyNativeAgentIdentity, configKeyOnlineAgentIdentity, "context_window", "enabled", "model", "system_prompt", "mcp_blocked_room_ids":
 		return true
 	default:
 		return false
 	}
+}
+
+func NativeAgentIdentity(cfg dirextalkdomain.AgentConfig) dirextalkdomain.AgentIdentityConfig {
+	return NormalizeConfig(cfg).NativeAgentIdentity
+}
+
+func OnlineAgentIdentity(cfg dirextalkdomain.AgentConfig) dirextalkdomain.AgentIdentityConfig {
+	return NormalizeConfig(cfg).OnlineAgentIdentity
+}
+
+func mergeIdentity(current dirextalkdomain.AgentIdentityConfig, value any) dirextalkdomain.AgentIdentityConfig {
+	raw, ok := value.(map[string]any)
+	if !ok {
+		return current
+	}
+	values := actionbase.Params(raw)
+	next := current
+	if displayName := values.String(configKeyDisplayName); displayName != "" {
+		next.DisplayName = displayName
+	}
+	if _, ok := raw[configKeyAvatarURL]; ok {
+		next.AvatarURL = values.String(configKeyAvatarURL)
+	}
+	return next
+}
+
+func normalizeIdentity(identity, fallback dirextalkdomain.AgentIdentityConfig) dirextalkdomain.AgentIdentityConfig {
+	identity.DisplayName = strings.TrimSpace(identity.DisplayName)
+	identity.AvatarURL = strings.TrimSpace(identity.AvatarURL)
+	fallback.DisplayName = strings.TrimSpace(fallback.DisplayName)
+	fallback.AvatarURL = strings.TrimSpace(fallback.AvatarURL)
+	if identity.DisplayName == "" && identity.AvatarURL == "" {
+		identity = fallback
+	}
+	if strings.TrimSpace(identity.DisplayName) == "" {
+		identity.DisplayName = fallbackString(fallback.DisplayName, "Agent")
+	}
+	return identity
+}
+
+func identityEmpty(identity dirextalkdomain.AgentIdentityConfig) bool {
+	return strings.TrimSpace(identity.DisplayName) == "" &&
+		strings.TrimSpace(identity.AvatarURL) == ""
+}
+
+func identityMap(identity dirextalkdomain.AgentIdentityConfig) map[string]any {
+	return map[string]any{
+		configKeyDisplayName: strings.TrimSpace(identity.DisplayName),
+		configKeyAvatarURL:   strings.TrimSpace(identity.AvatarURL),
+	}
+}
+
+func hasKey(values map[string]any, key string) bool {
+	_, ok := values[key]
+	return ok
+}
+
+func fallbackString(value, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value != "" {
+		return value
+	}
+	return strings.TrimSpace(fallback)
 }
 
 func cloneMap(values map[string]any) map[string]any {

--- a/p2p/internal/agent/config_test.go
+++ b/p2p/internal/agent/config_test.go
@@ -27,7 +27,15 @@ func TestNativeConfigMappingPreservesSharedAndNativeFields(t *testing.T) {
 	}
 
 	current := dirextalkdomain.AgentConfig{
-		DisplayName:   "Existing Agent",
+		DisplayName: "Existing Agent",
+		NativeAgentIdentity: dirextalkdomain.AgentIdentityConfig{
+			DisplayName: "Existing Ying",
+			AvatarURL:   "mxc://existing-ying",
+		},
+		OnlineAgentIdentity: dirextalkdomain.AgentIdentityConfig{
+			DisplayName: "Existing Online",
+			AvatarURL:   "mxc://existing-online",
+		},
 		ContextWindow: 30,
 		Enabled:       true,
 		Native:        map[string]any{"skills": []any{map[string]any{"id": "keep"}}},
@@ -35,10 +43,16 @@ func TestNativeConfigMappingPreservesSharedAndNativeFields(t *testing.T) {
 
 	next := FromNativeMap(current, map[string]any{
 		"display_name": " Updated Agent ",
+		"avatar_url":   " mxc://updated-ying ",
 		"model":        " model-v2 ",
 		"api_key":      "must-not-persist",
 	})
-	if next.DisplayName != "Updated Agent" || next.Model != "model-v2" || next.ContextWindow != 30 || !next.Enabled {
+	if next.DisplayName != "Updated Agent" || next.AvatarURL != "mxc://updated-ying" ||
+		next.NativeAgentIdentity.DisplayName != "Updated Agent" ||
+		next.NativeAgentIdentity.AvatarURL != "mxc://updated-ying" ||
+		next.OnlineAgentIdentity.DisplayName != "Existing Online" ||
+		next.OnlineAgentIdentity.AvatarURL != "mxc://existing-online" ||
+		next.Model != "model-v2" || next.ContextWindow != 30 || !next.Enabled {
 		t.Fatalf("unexpected mapped shared config: %#v", next)
 	}
 	if _, exposed := next.Native["api_key"]; exposed {
@@ -46,6 +60,67 @@ func TestNativeConfigMappingPreservesSharedAndNativeFields(t *testing.T) {
 	}
 	if _, ok := next.Native["skills"]; !ok {
 		t.Fatalf("mapped native config lost existing fields: %#v", next.Native)
+	}
+	nativeMap := ToNativeMap(next)
+	if nativeMap["display_name"] != "Updated Agent" || nativeMap["avatar_url"] != "mxc://updated-ying" {
+		t.Fatalf("native runtime config should expose Ying identity, got %#v", nativeMap)
+	}
+	if _, ok := next.Native["native_agent_identity"]; ok {
+		t.Fatalf("mode identities must not be stored as runtime Native fields: %#v", next.Native)
+	}
+}
+
+func TestApplyConfigUpdateMaintainsModeIdentities(t *testing.T) {
+	current := NormalizeConfig(dirextalkdomain.AgentConfig{
+		DisplayName: "Legacy",
+		AvatarURL:   "mxc://legacy",
+	})
+
+	nativeOnly := ApplyConfigUpdate(current, map[string]any{
+		"native_agent_identity": map[string]any{
+			"display_name": "Ying Prime",
+		},
+	})
+	if nativeOnly.DisplayName != "Ying Prime" ||
+		nativeOnly.NativeAgentIdentity.DisplayName != "Ying Prime" ||
+		nativeOnly.NativeAgentIdentity.AvatarURL != "mxc://legacy" ||
+		nativeOnly.OnlineAgentIdentity.DisplayName != "Legacy" ||
+		nativeOnly.OnlineAgentIdentity.AvatarURL != "mxc://legacy" {
+		t.Fatalf("native identity update leaked or dropped fields: %#v", nativeOnly)
+	}
+
+	onlineAvatarOnly := ApplyConfigUpdate(nativeOnly, map[string]any{
+		"online_agent_identity": map[string]any{
+			"avatar_url": " mxc://online ",
+		},
+	})
+	if onlineAvatarOnly.OnlineAgentIdentity.DisplayName != "Legacy" ||
+		onlineAvatarOnly.OnlineAgentIdentity.AvatarURL != "mxc://online" ||
+		onlineAvatarOnly.NativeAgentIdentity.DisplayName != "Ying Prime" ||
+		onlineAvatarOnly.NativeAgentIdentity.AvatarURL != "mxc://legacy" {
+		t.Fatalf("online avatar update should preserve names and Ying identity: %#v", onlineAvatarOnly)
+	}
+
+	legacyTopLevel := ApplyConfigUpdate(onlineAvatarOnly, map[string]any{
+		"display_name": "Shared Agent",
+		"avatar_url":   "mxc://shared",
+	})
+	if legacyTopLevel.NativeAgentIdentity.DisplayName != "Shared Agent" ||
+		legacyTopLevel.NativeAgentIdentity.AvatarURL != "mxc://shared" ||
+		legacyTopLevel.OnlineAgentIdentity.DisplayName != "Shared Agent" ||
+		legacyTopLevel.OnlineAgentIdentity.AvatarURL != "mxc://shared" {
+		t.Fatalf("legacy top-level update should sync both identities: %#v", legacyTopLevel)
+	}
+
+	nestedWins := ApplyConfigUpdate(legacyTopLevel, map[string]any{
+		"display_name": "Legacy Request",
+		"native_agent_identity": map[string]any{
+			"display_name": "Nested Ying",
+		},
+	})
+	if nestedWins.NativeAgentIdentity.DisplayName != "Nested Ying" ||
+		nestedWins.OnlineAgentIdentity.DisplayName != "Legacy Request" {
+		t.Fatalf("nested identity should win while top-level fills the other mode: %#v", nestedWins)
 	}
 }
 

--- a/p2p/internal/agent/module_test.go
+++ b/p2p/internal/agent/module_test.go
@@ -138,11 +138,38 @@ func TestAccountHandlersPreserveSessionAndConfigContracts(t *testing.T) {
 	if config["display_name"] != "Ops Agent" || config["enabled"] != false || config["model"] != "local-model" || config["system_prompt"] != "concise" {
 		t.Fatalf("unexpected public config: %#v", config)
 	}
+	nativeIdentity := config["native_agent_identity"].(map[string]any)
+	onlineIdentity := config["online_agent_identity"].(map[string]any)
+	if nativeIdentity["display_name"] != "Ops Agent" ||
+		onlineIdentity["display_name"] != "Ops Agent" {
+		t.Fatalf("legacy top-level update should sync mode identities: %#v", config)
+	}
 	if _, found := config["api_key"]; found || !account.published {
 		t.Fatalf("config must stay sanitized and disabling must publish offline: %#v published=%v", config, account.published)
 	}
 	blocked := config["mcp_blocked_room_ids"].([]string)
 	if len(blocked) != 1 || blocked[0] != "!secret:example.com" {
 		t.Fatalf("blocked rooms = %#v", blocked)
+	}
+
+	updated, actionErr = handlers["agent.config.update"](context.Background(), map[string]any{
+		"native_agent_identity": map[string]any{
+			"display_name": "Ying Prime",
+		},
+		"online_agent_identity": map[string]any{
+			"avatar_url": "mxc://example.com/online",
+		},
+	})
+	if actionErr != nil {
+		t.Fatalf("agent.config.update identities: %v", actionErr)
+	}
+	config = updated.(map[string]any)
+	nativeIdentity = config["native_agent_identity"].(map[string]any)
+	onlineIdentity = config["online_agent_identity"].(map[string]any)
+	if nativeIdentity["display_name"] != "Ying Prime" ||
+		nativeIdentity["avatar_url"] != "" ||
+		onlineIdentity["display_name"] != "Ops Agent" ||
+		onlineIdentity["avatar_url"] != "mxc://example.com/online" {
+		t.Fatalf("nested identity updates should merge independently: %#v", config)
 	}
 }

--- a/p2p/password_test.go
+++ b/p2p/password_test.go
@@ -114,7 +114,14 @@ func TestAgentMatrixSessionCreateUsesAgentIdentity(t *testing.T) {
 	issuer := &recordingMatrixSessionIssuer{}
 	service.SetMatrixSessionIssuer(issuer)
 	mustHandle[map[string]any](t, service, "agent.config.update", map[string]any{
-		"display_name": "Dirextalk Agent",
+		"native_agent_identity": map[string]any{
+			"display_name": "Ying Prime",
+			"avatar_url":   "mxc://example.com/ying",
+		},
+		"online_agent_identity": map[string]any{
+			"display_name": "Dirextalk Agent",
+			"avatar_url":   "mxc://example.com/online-agent",
+		},
 	})
 
 	session := mustHandle[map[string]any](t, service, "agent.matrix_session.create", map[string]any{
@@ -133,8 +140,8 @@ func TestAgentMatrixSessionCreateUsesAgentIdentity(t *testing.T) {
 	if issuer.sessionName != "Dirextalk Agent" {
 		t.Fatalf("expected Matrix issuer to use agent display name, got %q", issuer.sessionName)
 	}
-	if issuer.sessionURL != "" {
-		t.Fatalf("expected agent Matrix session avatar to be empty by default, got %q", issuer.sessionURL)
+	if issuer.sessionURL != "mxc://example.com/online-agent" {
+		t.Fatalf("expected Matrix issuer to use online agent avatar, got %q", issuer.sessionURL)
 	}
 	if session["device_id"] != "DIREXTALK_CLI" {
 		t.Fatalf("expected session device id to be DIREXTALK_CLI, got %#v", session)

--- a/p2p/service_agent_api.go
+++ b/p2p/service_agent_api.go
@@ -34,7 +34,9 @@ func (p serviceAgentAccountPort) CreateMatrixSession(ctx context.Context, params
 	p.service.mu.Lock()
 	issuer := p.service.sessions
 	userID := p.service.agentMXIDLocked()
-	displayName := p.service.agentDisplayNameLocked()
+	onlineIdentity := agentmodule.OnlineAgentIdentity(p.service.agentConfig)
+	displayName := onlineIdentity.DisplayName
+	avatarURL := onlineIdentity.AvatarURL
 	homeserver := p.service.homeserver
 	p.service.mu.Unlock()
 	session := agentmodule.MatrixSession{
@@ -45,7 +47,7 @@ func (p serviceAgentAccountPort) CreateMatrixSession(ctx context.Context, params
 	if issuer == nil {
 		return session, nil
 	}
-	token, err := issuer.EnsureMatrixSession(ctx, userID, displayName, "", requestedDeviceID, false)
+	token, err := issuer.EnsureMatrixSession(ctx, userID, displayName, avatarURL, requestedDeviceID, false)
 	if err != nil {
 		return agentmodule.MatrixSession{}, internalError(err)
 	}

--- a/p2p/storage_service_migration_test.go
+++ b/p2p/storage_service_migration_test.go
@@ -165,8 +165,16 @@ func TestDatabaseStoreRestoresPortalAndBusinessState(t *testing.T) {
 	post := mustHandle[channelPostRecord](t, service, "channels.posts.create", map[string]any{"channel_id": ch.ChannelID, "body": "post body"})
 	mustHandle[channelCommentRecord](t, service, "channels.comments.create", map[string]any{"channel_id": ch.ChannelID, "post_id": post.PostID, "body": "comment body"})
 	mustHandle[map[string]any](t, service, "agent.config.update", map[string]any{
-		"display_name":         "Storage Agent",
-		"avatar_url":           "mxc://example.com/storage-agent",
+		"display_name": "Storage Legacy Agent",
+		"avatar_url":   "mxc://example.com/storage-legacy-agent",
+		"native_agent_identity": map[string]any{
+			"display_name": "Storage Ying",
+			"avatar_url":   "mxc://example.com/storage-ying",
+		},
+		"online_agent_identity": map[string]any{
+			"display_name": "Storage Online",
+			"avatar_url":   "mxc://example.com/storage-online",
+		},
 		"context_window":       float64(96),
 		"enabled":              true,
 		"model":                "storage-model",
@@ -228,8 +236,14 @@ func TestDatabaseStoreRestoresPortalAndBusinessState(t *testing.T) {
 	}
 	agentConfig := mustHandle[map[string]any](t, reloaded, "agent.config.get", nil)
 	blockedRooms := agentConfig["mcp_blocked_room_ids"].([]string)
-	if agentConfig["display_name"] != "Storage Agent" ||
-		agentConfig["avatar_url"] != "mxc://example.com/storage-agent" ||
+	nativeIdentity := agentConfig["native_agent_identity"].(map[string]any)
+	onlineIdentity := agentConfig["online_agent_identity"].(map[string]any)
+	if agentConfig["display_name"] != "Storage Ying" ||
+		agentConfig["avatar_url"] != "mxc://example.com/storage-ying" ||
+		nativeIdentity["display_name"] != "Storage Ying" ||
+		nativeIdentity["avatar_url"] != "mxc://example.com/storage-ying" ||
+		onlineIdentity["display_name"] != "Storage Online" ||
+		onlineIdentity["avatar_url"] != "mxc://example.com/storage-online" ||
 		agentConfig["model"] != "storage-model" ||
 		agentConfig["system_prompt"] != "stored prompt" ||
 		int64Param(agentConfig["context_window"]) != 96 ||


### PR DESCRIPTION
解决现象：当前后端只维护单套 Agent 名称和头像字段，前端按 Ying / Your Agent 两套模式分别修改身份后，后端无法区分保存，容易导致返回聊天页或 Home 后名称、头像被另一套配置覆盖或重置。

旧逻辑：`agent.config.get/update` 主要围绕顶层 `display_name/avatar_url` 工作，Native Agent runtime 也会复用这组字段；Online Agent 创建 Matrix session 时同样读取单套 Agent 身份，Ying 和 Your Agent 没有后端一等隔离。

新逻辑：新增 `native_agent_identity` 和 `online_agent_identity` 两套 Agent 身份配置，分别对应 Ying 和 Your Agent。`agent.config.update` 支持 partial merge，只更新某一套或某个字段时不影响另一套；旧客户端只传顶层 `display_name/avatar_url` 时会同步更新两套身份；同时传顶层和 nested identity 时，以 nested 字段为准。Native runtime 继续读取 Ying 的有效身份，`agent.matrix_session.create` 改为读取 Your Agent 的有效身份。

影响范围：Agent 配置领域模型、`agent.config.get/update` 接口、Native Agent runtime config 映射、Online Agent Matrix session 创建、Agent 配置持久化 reload，以及对应契约文档和测试。

测试结果：
- 通过：`go test ./internal/dirextalkdomain ./p2p/internal/agent -count=1`
- 通过：`go test ./p2p -run 'TestAgentMatrixSessionCreateUsesAgentIdentity|TestNoDatabaseConstructorsUseIndependentSeededMemoryStores' -count=1`
- 通过：`go build ./cmd/dirextalk-message-server`
- 通过：`git diff --check`
- 接口验证通过：临时 HTTP 级测试实际调用 `POST /_p2p/command` 的 `agent.config.update/get`，验证只改 Ying、只改 Your Agent、头像-only 更新、legacy 顶层与 nested 同传时的优先级均符合预期；临时测试文件已删除。
- 说明：全量 `go test ./p2p -count=1` 在本地环境因缺少 Postgres 服务未完整通过，报错为 `localhost:5432 connection refused`，本次改动相关路径已用聚焦测试覆盖。