### PR TITLE
[codex] Add Agent session server-time contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           cache: true
       - name: Unit and release contract tests
         run: |
-          go test ./internal/releasecontrol ./internal/httputil ./setup ./p2p ./internal/productpolicy -count=1
+          go test ./internal/releasecontrol ./internal/httputil ./setup ./p2p ./p2p/internal/agent ./p2p/serviceapi ./internal/productpolicy -count=1
           go test -tags=dendrite_upgrade_tests ./cmd/dendrite-upgrade-tests -count=1
           bash scripts/release/contract_test.sh
       - name: Production build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # NOTE:
 # If you update this Dockerfile, ensure to sync your changes to the other
 # Dockerfiles in this repo (search *Dockerfile).
-ARG GO_BUILD_BASE=docker.io/library/golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2
+ARG GO_BUILD_BASE=docker.io/library/golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83
 ARG RUNTIME_BASE=docker.io/library/alpine:latest@sha256:55ae5d250caebc548793f321534bc6a8ef1d116f334f18f4ada1b2daad3251b2
 FROM --platform=${BUILDPLATFORM} ${GO_BUILD_BASE} AS base
 RUN apk --update --no-cache add bash build-base git

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Native Agent:
 - Default config path in Docker: `/etc/dirextalk-message-server/message-server.yaml`
 - Default data path in Docker: `/var/dirextalk-message-server`
 - Go module: `github.com/YingSuiAI/dirextalk-message-server`
-- Go version: `1.26.5`
+- Go version: `1.26.6`
 - Server database: PostgreSQL only; SQLite and file DSNs are unsupported.
 - Docker development database: PostgreSQL 18
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -32,7 +32,7 @@ Matrix 兼容 homeserver、ProductCore action、产品策略、projection、外�
 - Docker 默认配置路径：`/etc/dirextalk-message-server/message-server.yaml`
 - Docker 默认数据路径：`/var/dirextalk-message-server`
 - Go module：`github.com/YingSuiAI/dirextalk-message-server`
-- Go 版本：`1.26.5`
+- Go 版本：`1.26.6`
 - 服务端数据库：仅支持 PostgreSQL；不支持 SQLite 或 file DSN。
 - Docker 开发数据库：PostgreSQL 18
 

--- a/docs/agent-core-integration-development-contract.md
+++ b/docs/agent-core-integration-development-contract.md
@@ -36,6 +36,7 @@ response fields are:
 
 - `ticket`: compact Ed25519 JWS/JWT;
 - `expires_at`: UTC RFC3339 expiry;
+- `server_time`: UTC RFC3339 ticket issuance time;
 - `base_path`: `/agent/v1`;
 - `session_id`: canonical UUID;
 - `scopes`: the explicit current owner-client Agent scope set.
@@ -50,6 +51,11 @@ is mounted into Agent.
 Agent rejects expired tickets with `401 AGENT_TICKET_EXPIRED`. Missing scope,
 foreign owner, or stale account generation is `403`. The client cannot choose
 or widen scopes. Tickets and Authorization headers must not be logged.
+
+The versioned cross-consumer fixture
+[`agent_data_plane_contract_v1.json`](../p2p/internal/agent/testdata/agent_data_plane_contract_v1.json)
+freezes the session response fields, ticket lifetime, Agent ticket error codes,
+and SSE cursor-conflict code consumed by Agent and Flutter.
 
 ## HTTP and SSE semantics
 

--- a/docs/current-project-documentation.md
+++ b/docs/current-project-documentation.md
@@ -339,7 +339,7 @@ Multi-node：
 
 当前工具链：
 
-- Go 1.26.5。
+- Go 1.26.6。
 - 命令从仓库根目录执行。
 - Windows 使用 PowerShell；Linux、macOS 或 WSL 使用 Bash/Zsh。文档命令应按当前环境给出，不应强制限定为 WSL。
 

--- a/docs/product-action-contract.json
+++ b/docs/product-action-contract.json
@@ -265,6 +265,13 @@
               "type": "string"
             }
           },
+          "server_time": {
+            "type": "string",
+            "required": true,
+            "presence": {
+              "present": "rfc3339_utc"
+            }
+          },
           "session_id": {
             "type": "string",
             "required": true,

--- a/go.mod
+++ b/go.mod
@@ -126,4 +126,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.26.5
+go 1.26.6

--- a/p2p/internal/agent/account.go
+++ b/p2p/internal/agent/account.go
@@ -239,7 +239,7 @@ func (m *Module) createAgentSession(_ context.Context, params map[string]any) (a
 		return nil, actionbase.InternalError(err)
 	}
 	return map[string]any{
-		"ticket": ticket, "expires_at": expiresAt.Format(time.RFC3339),
+		"ticket": ticket, "expires_at": expiresAt.Format(time.RFC3339), "server_time": now.Format(time.RFC3339),
 		"base_path": agentSessionBasePath, "session_id": sessionID, "scopes": scopes,
 	}, nil
 }

--- a/p2p/internal/agent/session_ticket_test.go
+++ b/p2p/internal/agent/session_ticket_test.go
@@ -1,20 +1,38 @@
 package agent
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
+	"io"
+	"os"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 )
+
+type agentDataPlaneContractFixture struct {
+	Version         int `json:"version"`
+	SessionResponse struct {
+		RequiredFields   []string `json:"required_fields"`
+		BasePath         string   `json:"base_path"`
+		TimestampFormat  string   `json:"timestamp_format"`
+		TicketTTLSeconds int      `json:"ticket_ttl_seconds"`
+	} `json:"session_response"`
+	Errors map[string]string `json:"errors"`
+	SSE    map[string]string `json:"sse"`
+}
 
 func TestCreateAgentSessionSignsOwnerGenerationScopeAndExpiry(t *testing.T) {
 	publicKey, privateKey, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	now := time.Date(2026, 8, 16, 2, 3, 4, 0, time.UTC)
+	now := time.Date(2026, 8, 16, 10, 3, 4, 987000000, time.FixedZone("UTC+8", 8*60*60))
+	issuedAt := now.UTC().Truncate(time.Second)
 	sessionID := "7d369a99-c600-4a3d-ae3e-81611ddf73a1"
 	module := New(Config{
 		OwnerID: func() string { return "@owner:example.com" }, AccountGeneration: 9,
@@ -25,8 +43,23 @@ func TestCreateAgentSessionSignsOwnerGenerationScopeAndExpiry(t *testing.T) {
 		t.Fatalf("issue ticket: %v", actionErr)
 	}
 	response := result.(map[string]any)
-	if response["expires_at"] != "2026-08-16T02:18:04Z" || response["base_path"] != "/agent/v1" || response["session_id"] != sessionID {
+	if response["expires_at"] != "2026-08-16T02:18:04Z" || response["server_time"] != "2026-08-16T02:03:04Z" || response["base_path"] != "/agent/v1" || response["session_id"] != sessionID {
 		t.Fatalf("unexpected ticket response: %#v", response)
+	}
+	serverTime, err := time.Parse(time.RFC3339, response["server_time"].(string))
+	if err != nil || serverTime.Location() != time.UTC || !serverTime.Equal(issuedAt) {
+		t.Fatalf("server_time must be the RFC3339 UTC ticket issuance time: value=%#v parsed=%v err=%v", response["server_time"], serverTime, err)
+	}
+	contract := loadAgentDataPlaneContractV1(t)
+	gotFields := make([]string, 0, len(response))
+	for field := range response {
+		gotFields = append(gotFields, field)
+	}
+	sort.Strings(gotFields)
+	wantFields := append([]string(nil), contract.SessionResponse.RequiredFields...)
+	sort.Strings(wantFields)
+	if !reflect.DeepEqual(gotFields, wantFields) {
+		t.Fatalf("ticket response fields drifted: got=%v want=%v", gotFields, wantFields)
 	}
 	parts := strings.Split(response["ticket"].(string), ".")
 	if len(parts) != 3 {
@@ -60,13 +93,52 @@ func TestCreateAgentSessionSignsOwnerGenerationScopeAndExpiry(t *testing.T) {
 	if claims.Issuer != "dirextalk-message-server" || claims.Audience != agentSessionAudience || claims.Subject != "@owner:example.com" || claims.AccountGeneration != 9 {
 		t.Fatalf("ticket authority claims drifted: %#v", claims)
 	}
-	if claims.SessionID != sessionID || claims.Nonce == "" || claims.IssuedAt != now.Unix() || claims.ExpiresAt != now.Add(agentSessionTTL).Unix() {
+	if claims.SessionID != sessionID || claims.Nonce == "" || claims.IssuedAt != serverTime.Unix() || claims.ExpiresAt != serverTime.Add(agentSessionTTL).Unix() {
 		t.Fatalf("ticket lifetime/session claims drifted: %#v", claims)
 	}
 	wantScopes := strings.Join(agentSessionScopes, ",")
 	if strings.Join(claims.Scopes, ",") != wantScopes || strings.Join(response["scopes"].([]string), ",") != wantScopes {
 		t.Fatalf("ticket scopes drifted: claims=%v response=%v", claims.Scopes, response["scopes"])
 	}
+}
+
+func TestAgentDataPlaneContractV1Fixture(t *testing.T) {
+	got := loadAgentDataPlaneContractV1(t)
+	want := agentDataPlaneContractFixture{
+		Version: 1,
+		Errors: map[string]string{
+			"expired":         "AGENT_TICKET_EXPIRED",
+			"stale":           "AGENT_TICKET_STALE",
+			"invalid":         "AGENT_TICKET_INVALID",
+			"scope_forbidden": "AGENT_TICKET_SCOPE_FORBIDDEN",
+		},
+		SSE: map[string]string{"cursor_conflict": "AGENT_CURSOR_CONFLICT"},
+	}
+	want.SessionResponse.RequiredFields = []string{"ticket", "expires_at", "server_time", "base_path", "session_id", "scopes"}
+	want.SessionResponse.BasePath = agentSessionBasePath
+	want.SessionResponse.TimestampFormat = "rfc3339_utc"
+	want.SessionResponse.TicketTTLSeconds = int(agentSessionTTL / time.Second)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("v1 Agent data-plane contract fixture drifted: got=%#v want=%#v", got, want)
+	}
+}
+
+func loadAgentDataPlaneContractV1(t *testing.T) agentDataPlaneContractFixture {
+	t.Helper()
+	data, err := os.ReadFile("testdata/agent_data_plane_contract_v1.json")
+	if err != nil {
+		t.Fatalf("read v1 Agent data-plane contract fixture: %v", err)
+	}
+	var fixture agentDataPlaneContractFixture
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&fixture); err != nil {
+		t.Fatalf("decode v1 Agent data-plane contract fixture: %v", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("v1 Agent data-plane contract fixture has trailing JSON: %v", err)
+	}
+	return fixture
 }
 
 func TestCreateAgentSessionRejectsInvalidRefreshOrMissingAuthority(t *testing.T) {

--- a/p2p/internal/agent/testdata/agent_data_plane_contract_v1.json
+++ b/p2p/internal/agent/testdata/agent_data_plane_contract_v1.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "session_response": {
+    "required_fields": [
+      "ticket",
+      "expires_at",
+      "server_time",
+      "base_path",
+      "session_id",
+      "scopes"
+    ],
+    "base_path": "/agent/v1",
+    "timestamp_format": "rfc3339_utc",
+    "ticket_ttl_seconds": 900
+  },
+  "errors": {
+    "expired": "AGENT_TICKET_EXPIRED",
+    "stale": "AGENT_TICKET_STALE",
+    "invalid": "AGENT_TICKET_INVALID",
+    "scope_forbidden": "AGENT_TICKET_SCOPE_FORBIDDEN"
+  },
+  "sse": {
+    "cursor_conflict": "AGENT_CURSOR_CONFLICT"
+  }
+}

--- a/p2p/routing_test.go
+++ b/p2p/routing_test.go
@@ -94,7 +94,7 @@ func TestAgentSessionCreateRequiresOwnerAccessToken(t *testing.T) {
 	if err := json.Unmarshal(ownerResponse.Body.Bytes(), &got); err != nil {
 		t.Fatal(err)
 	}
-	if got["ticket"] == "" || got["base_path"] != "/agent/v1" || got["session_id"] == "" {
+	if got["ticket"] == "" || got["base_path"] != "/agent/v1" || got["session_id"] == "" || got["server_time"] == "" {
 		t.Fatalf("unexpected ticket response: %#v", got)
 	}
 }

--- a/p2p/serviceapi/action_contract_test.go
+++ b/p2p/serviceapi/action_contract_test.go
@@ -80,3 +80,14 @@ func TestActionSpecCopiesDeepCloneNestedSchemas(t *testing.T) {
 		t.Fatal("mutating a generated action contract schema contaminated later contracts")
 	}
 }
+
+func TestAgentSessionCreatePublishesRequiredServerTime(t *testing.T) {
+	spec, ok := ActionSpecFor("agent.session.create")
+	if !ok || spec.Schema == nil {
+		t.Fatal("agent.session.create must publish a schema")
+	}
+	serverTime, ok := spec.Schema.Response["server_time"]
+	if !ok || serverTime.Type != "string" || !serverTime.Required || serverTime.Presence == nil || serverTime.Presence.Present != "rfc3339_utc" {
+		t.Fatalf("agent.session.create server_time schema drifted: %#v", serverTime)
+	}
+}

--- a/p2p/serviceapi/agent_session_action_schema.go
+++ b/p2p/serviceapi/agent_session_action_schema.go
@@ -6,11 +6,12 @@ func agentSessionCreateSchema() *ActionSchema {
 			"session_id": {Type: "string", Presence: &ActionPresenceSchema{Omitted: "new_session", Present: "canonical_uuid;refresh_same_session"}},
 		},
 		Response: map[string]ActionFieldSchema{
-			"ticket":     {Type: "string", Required: true, WriteOnly: true, Presence: &ActionPresenceSchema{Present: "short_lived_compact_eddsa_jws"}},
-			"expires_at": {Type: "string", Required: true, Presence: &ActionPresenceSchema{Present: "rfc3339_utc"}},
-			"base_path":  {Type: "string", Required: true, Presence: &ActionPresenceSchema{Present: "/agent/v1"}},
-			"session_id": {Type: "string", Required: true, Presence: &ActionPresenceSchema{Present: "canonical_uuid"}},
-			"scopes":     {Type: "array", Required: true, Items: &ActionFieldSchema{Type: "string"}},
+			"ticket":      {Type: "string", Required: true, WriteOnly: true, Presence: &ActionPresenceSchema{Present: "short_lived_compact_eddsa_jws"}},
+			"expires_at":  {Type: "string", Required: true, Presence: &ActionPresenceSchema{Present: "rfc3339_utc"}},
+			"server_time": {Type: "string", Required: true, Presence: &ActionPresenceSchema{Present: "rfc3339_utc"}},
+			"base_path":   {Type: "string", Required: true, Presence: &ActionPresenceSchema{Present: "/agent/v1"}},
+			"session_id":  {Type: "string", Required: true, Presence: &ActionPresenceSchema{Present: "canonical_uuid"}},
+			"scopes":      {Type: "array", Required: true, Items: &ActionFieldSchema{Type: "string"}},
 		},
 	}
 }

--- a/scripts/release/contract_test.sh
+++ b/scripts/release/contract_test.sh
@@ -36,6 +36,11 @@ if grep -Ein 'attestat|sbom|provenance|imagetools inspect|index digest|latest.*m
   "$lib" "$prepare" "$verify" "$publish"; then
   fail 'active release scripts still contain retired publication gates'
 fi
+required_test_command='go test ./internal/releasecontrol ./internal/httputil ./setup ./p2p ./p2p/internal/agent ./p2p/serviceapi ./internal/productpolicy -count=1'
+for test_entrypoint in "$repo_root/.github/workflows/ci.yml" "$verify"; do
+  grep -F "$required_test_command" "$test_entrypoint" >/dev/null || \
+    fail "${test_entrypoint#"$repo_root"/} does not run Agent implementation and service API contract tests"
+done
 
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT

--- a/scripts/release/verify.sh
+++ b/scripts/release/verify.sh
@@ -10,7 +10,7 @@ release_require_context "$RELEASE_VERSION"
 release_require_tools go docker
 cd "$RELEASE_REPO_ROOT"
 
-go test ./internal/releasecontrol ./internal/httputil ./setup ./p2p ./internal/productpolicy -count=1
+go test ./internal/releasecontrol ./internal/httputil ./setup ./p2p ./p2p/internal/agent ./p2p/serviceapi ./internal/productpolicy -count=1
 go test -tags=dendrite_upgrade_tests ./cmd/dendrite-upgrade-tests -count=1
 go build ./cmd/dirextalk-message-server
 


### PR DESCRIPTION
## What changed

- require RFC3339 UTC `server_time` in `agent.session.create`
- bind `server_time` and ticket `iat` to the same truncated UTC instant
- synchronize schemas, documentation, and the shared v1 fixture
- explicitly cover `p2p/internal/agent` and `p2p/serviceapi` in CI and release checks
- align the Message Server Go module and digest-pinned Docker builder on Go 1.26.6

## Why

Clients need a server-relative expiry baseline so device wall-clock drift cannot invalidate or overextend Agent sessions. The previously implicit package coverage also left the Agent boundary easy to omit from release gates. Aligning the builder with the module directive prevents image builds from lagging the maintained Go toolchain shared with Agent.

## Impact

Flutter can derive a monotonic ticket lifetime with a safety window, Message Server release checks directly exercise the Agent session contract, and the production builder uses the same maintained Go 1.26.6 input as Agent while keeping a separate Message Server runtime image.

## Validation

- focused Go suites (657 existing contract tests plus 23 builder-adjacent package tests)
- `scripts/release/contract_test.sh`
- `go mod verify`
- `go build ./cmd/dirextalk-message-server`
- Docker `base` stage and in-container `go version go1.26.6 linux/amd64`
- `go vet ./...`
- `gopls check`
- `git diff --check`
