### PR TITLE
[codex] Release Message Server v1.1.63

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -12,7 +12,7 @@ const (
 
 // These values are overridden for release builds with -ldflags -X.
 var (
-	version   = "v1.1.62"
+	version   = "v1.1.63"
 	commit    string
 	buildTime string
 )

--- a/release/RELEASE_NOTES.md
+++ b/release/RELEASE_NOTES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v1.1.63
+
+1. Return the RFC3339 UTC `server_time` in owner Agent session tickets so clients can derive ticket lifetime from a monotonic clock without trusting the device wall clock.
+2. Build the Message Server with Go 1.26.6.
+
 ## v1.1.62
 
 1. Remove the retired ProductCore-to-Agent MCP gateway test surface and require current direct Agent HTTP settings during Agent updates instead of migrating legacy gateway configuration.

--- a/release/v1.1.63.json
+++ b/release/v1.1.63.json
@@ -1,0 +1,7 @@
+{
+  "version": "v1.1.63",
+  "minimum_client_version": "v1.0.0",
+  "maximum_client_version_exclusive": "v2.0.0",
+  "schema_version": 2,
+  "schema_compat_version": 1
+}


### PR DESCRIPTION
## What changed

- set the Message Server source version to v1.1.63
- add release metadata and notes for the required Agent session server_time contract
- record the Go 1.26.6 build toolchain update

## Why

Flutter PR #17 requires server_time to derive ticket lifetime without trusting the device wall clock. Message Server v1.1.62 omits the field, so Native Agent configuration and discovery fail before reaching Agent.

## Verification

- focused Agent session/routing Go tests
- release contract tests
- git diff --check