### PR TITLE
[codex] release: prepare Message Server v1.1.64

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -12,7 +12,7 @@ const (
 
 // These values are overridden for release builds with -ldflags -X.
 var (
-	version   = "v1.1.63"
+	version   = "v1.1.64"
 	commit    string
 	buildTime string
 )

--- a/release/RELEASE_NOTES.md
+++ b/release/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v1.1.64
+
+1. Advertise explicit standard MCP tool annotations so clients can distinguish idempotent reads from non-idempotent message and comment writes without relying on tool names or protocol defaults.
+2. Adopt `dirextalk-capability-api` v1.1.0 generated Agent data-plane v2 types and shared conformance vectors as the cross-service session response contract.
+3. Preserve established Matrix and ProductCore public error messages while tightening internal error handling and full-repository static analysis.
+
 ## v1.1.63
 
 1. Return the RFC3339 UTC `server_time` in owner Agent session tickets so clients can derive ticket lifetime from a monotonic clock without trusting the device wall clock.

--- a/release/v1.1.64.json
+++ b/release/v1.1.64.json
@@ -1,0 +1,7 @@
+{
+  "version": "v1.1.64",
+  "minimum_client_version": "v1.0.0",
+  "maximum_client_version_exclusive": "v2.0.0",
+  "schema_version": 2,
+  "schema_compat_version": 1
+}


### PR DESCRIPTION
## Summary

- bump the canonical Message Server version to `v1.1.64`
- add the matching release manifest while preserving the existing client and schema compatibility bounds
- document the audited MCP tool-effect annotations, shared Capability API v1.1.0 Agent data-plane contract, and preserved public error contracts

## Impact

This prepares the repository metadata for the next stable Message Server release. It does not tag or publish the release, build or push images, change deployment state, or alter production.

## Validation

- `bash scripts/release/contract_test.sh`
- `go test ./internal ./internal/releasecontrol -count=1` (98 tests passed)
- `git diff --check origin/main...HEAD`
