### PR TITLE
[codex] ci: run routine checks on version tags only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 
 on:
-  pull_request:
   push:
-    branches:
-      - main
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 


### PR DESCRIPTION
## Summary

- run the routine Message Server CI workflow only for semantic version tag pushes matching `vX.Y.Z`
- remove pull-request and `main` push triggers from the routine workflow
- leave the manually dispatched stable release workflow unchanged

## Why

The full routine backend gate is intended to validate formal version-tag publication rather than run for every pull request or merge to `main`.

## Impact

Pull requests and ordinary `main` pushes will no longer start `.github/workflows/ci.yml`. A matching version tag push will still run the complete routine gate, while `.github/workflows/release.yml` remains manually dispatched.

## Validation

- parsed `.github/workflows/ci.yml` with PyYAML
- verified the trigger block contains only the `vX.Y.Z` tag push contract
- verified `.github/workflows/release.yml` is unchanged
- `git diff --check`

No Go tests were rerun because this change affects workflow triggers only.
